### PR TITLE
Task/#21 address transaction pagination

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -427,7 +427,6 @@
       "version": "5.5.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-      "dev": true,
       "requires": {
         "co": "4.6.0",
         "fast-deep-equal": "1.0.0",
@@ -694,8 +693,7 @@
     "asn1": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-      "dev": true
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
     },
     "asn1.js": {
       "version": "4.9.2",
@@ -784,8 +782,7 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "atob": {
       "version": "2.0.3",
@@ -816,8 +813,7 @@
     "aws4": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
-      "dev": true
+      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
     },
     "axios": {
       "version": "0.15.3",
@@ -1021,7 +1017,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-      "dev": true,
       "optional": true,
       "requires": {
         "tweetnacl": "0.14.5"
@@ -1658,8 +1653,7 @@
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-      "dev": true
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "center-align": {
       "version": "0.1.3",
@@ -1908,8 +1902,7 @@
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-      "dev": true
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
     },
     "coa": {
       "version": "1.0.4",
@@ -2052,7 +2045,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
       "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-      "dev": true,
       "requires": {
         "delayed-stream": "1.0.0"
       }
@@ -2305,8 +2297,7 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cosmiconfig": {
       "version": "2.2.2",
@@ -2708,7 +2699,6 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "dev": true,
       "requires": {
         "assert-plus": "1.0.0"
       },
@@ -2716,8 +2706,7 @@
         "assert-plus": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         }
       }
     },
@@ -2869,8 +2858,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "delegates": {
       "version": "1.0.0",
@@ -3121,7 +3109,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-      "dev": true,
       "optional": true,
       "requires": {
         "jsbn": "0.1.1"
@@ -3266,7 +3253,8 @@
     "entities": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
-      "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA="
+      "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
+      "dev": true
     },
     "errno": {
       "version": "0.1.6",
@@ -3685,8 +3673,7 @@
     "extend": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
-      "dev": true
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
     },
     "extend-shallow": {
       "version": "2.0.1",
@@ -3721,20 +3708,17 @@
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-      "dev": true
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "fast-deep-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
-      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
-      "dev": true
+      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-      "dev": true
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -3889,8 +3873,7 @@
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-      "dev": true
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
       "version": "2.1.4",
@@ -5020,7 +5003,6 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "dev": true,
       "requires": {
         "assert-plus": "1.0.0"
       },
@@ -5028,8 +5010,7 @@
         "assert-plus": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         }
       }
     },
@@ -6218,8 +6199,7 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-      "dev": true
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "is-utf8": {
       "version": "0.2.1",
@@ -6263,8 +6243,7 @@
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-      "dev": true
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "istanbul-api": {
       "version": "1.2.1",
@@ -6455,7 +6434,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "dev": true,
       "optional": true
     },
     "jsesc": {
@@ -6473,14 +6451,12 @@
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-      "dev": true
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
     "json-schema-traverse": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
-      "dev": true
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
     },
     "json-stable-stringify": {
       "version": "1.0.1",
@@ -6494,8 +6470,7 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "dev": true
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "json3": {
       "version": "3.3.2",
@@ -6541,7 +6516,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-      "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
@@ -6552,8 +6526,7 @@
         "assert-plus": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         }
       }
     },
@@ -7256,11 +7229,6 @@
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
     },
-    "medium-json-feed": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/medium-json-feed/-/medium-json-feed-0.0.2.tgz",
-      "integrity": "sha512-CSM48+KZdRKa3rZ8KMsFWzxdGGMOeP7xP4ahTU86jZouRzIDJ/dKQI//L/cQ8O9GXjfSvyE8WCRdq+V7zan/SQ=="
-    },
     "mem": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
@@ -7358,14 +7326,12 @@
     "mime-db": {
       "version": "1.30.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
-      "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE=",
-      "dev": true
+      "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
     },
     "mime-types": {
       "version": "2.1.17",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
       "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
-      "dev": true,
       "requires": {
         "mime-db": "1.30.0"
       }
@@ -8034,8 +8000,7 @@
     "oauth-sign": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
-      "dev": true
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
     },
     "object-assign": {
       "version": "4.1.1",
@@ -10773,8 +10738,7 @@
     "punycode": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-      "dev": true
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
     },
     "q": {
       "version": "1.5.1",
@@ -11346,13 +11310,158 @@
       "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.0.0.tgz",
       "integrity": "sha1-nbOE/0uJqPYVY9kjldhiWxjzr7A="
     },
-    "rss-parser": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/rss-parser/-/rss-parser-3.1.1.tgz",
-      "integrity": "sha512-NAw0lOA89YCtYG270ZC1zHs2ExETi0APQJpUqRGeg+D2fVHi4HNKKSZcOetAy2vLpULmjdQOZQyO9Pr63wN/CQ==",
+    "rss-to-json": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/rss-to-json/-/rss-to-json-1.0.4.tgz",
+      "integrity": "sha512-rldG9HGOPZMYk2tE13lpWNd6AvizUS/Vcr7+6dIL4xdbF7PhkROcau5Ur4ygv++DUyTUeU+SBzrP5MGUM/CRqg==",
       "requires": {
-        "entities": "1.1.1",
+        "request": "2.83.0",
         "xml2js": "0.4.19"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        },
+        "aws-sign2": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+          "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+        },
+        "boom": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+          "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+          "requires": {
+            "hoek": "4.2.1"
+          }
+        },
+        "cryptiles": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+          "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+          "requires": {
+            "boom": "5.2.0"
+          },
+          "dependencies": {
+            "boom": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+              "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+              "requires": {
+                "hoek": "4.2.1"
+              }
+            }
+          }
+        },
+        "form-data": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+          "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.6",
+            "mime-types": "2.1.17"
+          },
+          "dependencies": {
+            "combined-stream": {
+              "version": "1.0.6",
+              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+              "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+              "requires": {
+                "delayed-stream": "1.0.0"
+              }
+            }
+          }
+        },
+        "har-schema": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+          "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+        },
+        "har-validator": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+          "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+          "requires": {
+            "ajv": "5.5.2",
+            "har-schema": "2.0.0"
+          }
+        },
+        "hawk": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+          "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+          "requires": {
+            "boom": "4.3.1",
+            "cryptiles": "3.1.2",
+            "hoek": "4.2.1",
+            "sntp": "2.1.0"
+          }
+        },
+        "hoek": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+          "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
+        },
+        "http-signature": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+          "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+          "requires": {
+            "assert-plus": "1.0.0",
+            "jsprim": "1.4.1",
+            "sshpk": "1.13.1"
+          }
+        },
+        "performance-now": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+          "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+        },
+        "qs": {
+          "version": "6.5.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+        },
+        "request": {
+          "version": "2.83.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
+          "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+          "requires": {
+            "aws-sign2": "0.7.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.3.2",
+            "har-validator": "5.0.3",
+            "hawk": "6.0.2",
+            "http-signature": "1.2.0",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.17",
+            "oauth-sign": "0.8.2",
+            "performance-now": "2.1.0",
+            "qs": "6.5.1",
+            "safe-buffer": "5.1.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.3",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.2.1"
+          }
+        },
+        "sntp": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+          "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+          "requires": {
+            "hoek": "4.2.1"
+          }
+        }
       }
     },
     "run-queue": {
@@ -12158,7 +12267,6 @@
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
       "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
-      "dev": true,
       "requires": {
         "asn1": "0.2.3",
         "assert-plus": "1.0.0",
@@ -12173,8 +12281,7 @@
         "assert-plus": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         }
       }
     },
@@ -12392,8 +12499,7 @@
     "stringstream": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
-      "dev": true
+      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
     },
     "strip-ansi": {
       "version": "3.0.1",
@@ -12777,7 +12883,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
       "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
-      "dev": true,
       "requires": {
         "punycode": "1.4.1"
       }
@@ -12982,7 +13087,6 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "dev": true,
       "requires": {
         "safe-buffer": "5.1.1"
       }
@@ -12991,7 +13095,6 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "dev": true,
       "optional": true
     },
     "type-check": {
@@ -13466,8 +13569,7 @@
     "uuid": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
-      "dev": true
+      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
     },
     "uws": {
       "version": "0.14.5",
@@ -13511,7 +13613,6 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "core-util-is": "1.0.2",
@@ -13521,8 +13622,7 @@
         "assert-plus": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         }
       }
     },

--- a/src/app/explorer/explorer.module.ts
+++ b/src/app/explorer/explorer.module.ts
@@ -1,7 +1,9 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
+import { FormsModule } from '@angular/forms';
 import { EffectsModule } from '@ngrx/effects';
 import { StoreModule } from '@ngrx/store';
+import { PaginationModule } from 'ngx-bootstrap';
 
 import { BlockOverviewComponent } from './components/block-overview/block-overview.component';
 import { BlocksPanelComponent } from './components/blocks-panel/blocks-panel.component';
@@ -33,6 +35,8 @@ import { reducers } from './state/reducers';
       TransactionsEffects,
     ]),
     ExplorerRoutingModule,
+    PaginationModule.forRoot(),
+    FormsModule,
   ],
   declarations: [
     OverviewComponent,

--- a/src/app/explorer/models/address-transactions.ts
+++ b/src/app/explorer/models/address-transactions.ts
@@ -1,0 +1,8 @@
+import { Transaction } from './transaction';
+
+export interface AddressTransactions {
+  transactions: Transaction[];
+  totalPages: number;
+  currentPage: number;
+  totalTransactions: number;
+}

--- a/src/app/explorer/pages/address-details/address-details.component.html
+++ b/src/app/explorer/pages/address-details/address-details.component.html
@@ -44,12 +44,12 @@
         </div>
       </div>
     </div>
-    <ng-container *ngIf="addressTransactions">
+    <ng-container *ngIf="addressTransactions$ | async as addressTransactions">
       <div class="row">
-          <div class="col">
-            <pagination [totalItems]="addressTransactions.totalTransactions" [maxSize]="6" class="pagination-sm" [(ngModel)]="currentPage" [itemsPerPage]="20"
-            [boundaryLinks]="true" [rotate]="false" (pageChanged)="pageAddressTransactions($event)" (numPages)="numPages = addressTransactions.totalPages"></pagination>
-          </div>
+        <div class="col">
+          <pagination class="pagination-sm" [totalItems]="addressTransactions.totalTransactions" [maxSize]="6" [(ngModel)]="currentPage"
+            [itemsPerPage]="20" [boundaryLinks]="true" [rotate]="false" (pageChanged)="pageAddressTransactions($event)" (numPages)="numPages = addressTransactions.totalPages"></pagination>
+        </div>
       </div>
       <div class="row">
         <div class="col">
@@ -72,14 +72,16 @@
               <ng-template #sentAction>
                 <a [routerLink]="['/explorer', 'address', transaction.to]" class="transaction-action-link">
                   <div class="transaction-action">
-                    <span class="text-truncate"><span class="bold text-uppercase">TO</span> {{ transaction.to }}</span>
+                    <span class="text-truncate">
+                      <span class="bold text-uppercase">TO</span> {{ transaction.to }}</span>
                   </div>
                 </a>
               </ng-template>
               <ng-template #receivedAction>
                 <a [routerLink]="['/explorer', 'address', transaction.from]" class="transaction-action-link">
                   <div class="transaction-action">
-                    <span class="text-truncate"><span class="bold text-uppercase">FROM</span> {{ transaction.from }}</span>
+                    <span class="text-truncate">
+                      <span class="bold text-uppercase">FROM</span> {{ transaction.from }}</span>
                   </div>
                 </a>
               </ng-template>
@@ -94,11 +96,10 @@
         </div>
       </div>
       <div class="row">
-          <div class="col">
-            {{ addressTransactions }}
-            <pagination [totalItems]="addressTransactions.totalTransactions" [maxSize]="6" class="pagination-sm" [ngModel]="currentPage" [itemsPerPage]="20"
-            [boundaryLinks]="true" [rotate]="false" (pageChanged)="pageAddressTransactions($event)" (numPages)="numPages = addressTransactions.totalPages"></pagination>
-          </div>
+        <div class="col">
+          <pagination class="pagination-sm" [totalItems]="addressTransactions.totalTransactions" [maxSize]="6" [(ngModel)]="currentPage"
+            [itemsPerPage]="20" [boundaryLinks]="true" [rotate]="false" (pageChanged)="pageAddressTransactions($event)" (numPages)="numPages = addressTransactions.totalPages"></pagination>
+        </div>
       </div>
     </ng-container>
   </div>

--- a/src/app/explorer/pages/address-details/address-details.component.html
+++ b/src/app/explorer/pages/address-details/address-details.component.html
@@ -48,7 +48,7 @@
       <div class="row">
         <div class="col">
           <pagination class="pagination-sm" [totalItems]="addressTransactions.totalTransactions" [maxSize]="6" [(ngModel)]="currentPage"
-            [itemsPerPage]="20" [boundaryLinks]="true" [rotate]="false" (pageChanged)="pageAddressTransactions($event)" (numPages)="numPages = addressTransactions.totalPages"></pagination>
+            previousText="<" nextText=">" [itemsPerPage]="20" [rotate]="false" (pageChanged)="pageAddressTransactions($event)" (numPages)="numPages = addressTransactions.totalPages"></pagination>
         </div>
       </div>
       <div class="row">
@@ -98,7 +98,7 @@
       <div class="row">
         <div class="col">
           <pagination class="pagination-sm" [totalItems]="addressTransactions.totalTransactions" [maxSize]="6" [(ngModel)]="currentPage"
-            [itemsPerPage]="20" [boundaryLinks]="true" [rotate]="false" (pageChanged)="pageAddressTransactions($event)" (numPages)="numPages = addressTransactions.totalPages"></pagination>
+            previousText="<" nextText=">" [itemsPerPage]="20" [rotate]="false" (pageChanged)="pageAddressTransactions($event)" (numPages)="numPages = addressTransactions.totalPages"></pagination>
         </div>
       </div>
     </ng-container>

--- a/src/app/explorer/pages/address-details/address-details.component.html
+++ b/src/app/explorer/pages/address-details/address-details.component.html
@@ -44,19 +44,14 @@
         </div>
       </div>
     </div>
-    <div class="row">
-      <ng-container *ngIf="addressTransactions$ | async as addressTransactions">
-        <div class="col">
-          <div class="row">
-            <button *ngIf="addressTransactions.currentPage > 0" (click)="pageNextAddressTransactions(address.hash, addressTransactions.currentPage - 1)">
-              Previous
-            </button>
-            <button (click)="pageNextAddressTransactions(address.hash, addressTransactions.currentPage + 1)">
-              Next
-            </button>
-            Page {{ addressTransactions.currentPage + 1 }} of {{ addressTransactions.totalPages + 1 }}
+    <ng-container *ngIf="addressTransactions">
+      <div class="row">
+          <div class="col">
+            <pagination [totalItems]="addressTransactions.totalTransactions" [maxSize]="6" class="pagination-sm" [(ngModel)]="currentPage" [itemsPerPage]="20"
+            [boundaryLinks]="true" [rotate]="false" (pageChanged)="pageAddressTransactions($event)" (numPages)="numPages = addressTransactions.totalPages"></pagination>
           </div>
-        </div>
+      </div>
+      <div class="row">
         <div class="col">
           <div *ngFor="let transaction of addressTransactions.transactions">
             <div class="transaction-grid">
@@ -97,7 +92,14 @@
             </div>
           </div>
         </div>
-      </ng-container>
-    </div>
+      </div>
+      <div class="row">
+          <div class="col">
+            {{ addressTransactions }}
+            <pagination [totalItems]="addressTransactions.totalTransactions" [maxSize]="6" class="pagination-sm" [ngModel]="currentPage" [itemsPerPage]="20"
+            [boundaryLinks]="true" [rotate]="false" (pageChanged)="pageAddressTransactions($event)" (numPages)="numPages = addressTransactions.totalPages"></pagination>
+          </div>
+      </div>
+    </ng-container>
   </div>
 </ng-container>

--- a/src/app/explorer/pages/address-details/address-details.component.html
+++ b/src/app/explorer/pages/address-details/address-details.component.html
@@ -48,7 +48,7 @@
       <div class="row">
         <div class="col">
           <pagination class="pagination-sm" [totalItems]="addressTransactions.totalTransactions" [maxSize]="6" [(ngModel)]="currentPage"
-            previousText="<" nextText=">" [itemsPerPage]="20" [rotate]="false" (pageChanged)="pageAddressTransactions($event)" (numPages)="numPages = addressTransactions.totalPages"></pagination>
+            previousText="&nbsp;" nextText="&nbsp;" [itemsPerPage]="20" [rotate]="false" (pageChanged)="pageAddressTransactions($event)" (numPages)="numPages = addressTransactions.totalPages"></pagination>
         </div>
       </div>
       <div class="row">
@@ -98,7 +98,7 @@
       <div class="row">
         <div class="col">
           <pagination class="pagination-sm" [totalItems]="addressTransactions.totalTransactions" [maxSize]="6" [(ngModel)]="currentPage"
-            previousText="<" nextText=">" [itemsPerPage]="20" [rotate]="false" (pageChanged)="pageAddressTransactions($event)" (numPages)="numPages = addressTransactions.totalPages"></pagination>
+            previousText="&nbsp;" nextText="&nbsp;" [itemsPerPage]="20" [rotate]="false" (pageChanged)="pageAddressTransactions($event)" (numPages)="numPages = addressTransactions.totalPages"></pagination>
         </div>
       </div>
     </ng-container>

--- a/src/app/explorer/pages/address-details/address-details.component.html
+++ b/src/app/explorer/pages/address-details/address-details.component.html
@@ -45,46 +45,59 @@
       </div>
     </div>
     <div class="row">
-      <div class="col">
-        <div *ngFor="let transaction of address.transactions">
-          <div class="transaction-grid">
-            <div class="transaction-icon">
-              <img *ngIf="transaction.from === address.hash; else receivedIcon" src="../../../../assets/images/icon-sent.svg" alt="Sent">
-              <ng-template #receivedIcon>
-                <img src="../../../../assets/images/icon-received.svg" alt="Received">
-              </ng-template>
-            </div>
-            <a [routerLink]="['/explorer', 'transaction', transaction.hash]" class="transaction-hash-link">
-              <div class="transaction-hash">
-                <span class="text-truncate">
-                  {{ transaction.hash }}
-                </span>
+      <ng-container *ngIf="addressTransactions$ | async as addressTransactions">
+        <div class="col">
+          <div class="row">
+            <button *ngIf="addressTransactions.currentPage > 0" (click)="pageNextAddressTransactions(address.hash, addressTransactions.currentPage - 1)">
+              Previous
+            </button>
+            <button (click)="pageNextAddressTransactions(address.hash, addressTransactions.currentPage + 1)">
+              Next
+            </button>
+            Page {{ addressTransactions.currentPage + 1 }} of {{ addressTransactions.totalPages + 1 }}
+          </div>
+        </div>
+        <div class="col">
+          <div *ngFor="let transaction of addressTransactions.transactions">
+            <div class="transaction-grid">
+              <div class="transaction-icon">
+                <img *ngIf="transaction.from === address.hash; else receivedIcon" src="../../../../assets/images/icon-sent.svg" alt="Sent">
+                <ng-template #receivedIcon>
+                  <img src="../../../../assets/images/icon-received.svg" alt="Received">
+                </ng-template>
               </div>
-            </a>
-            <ng-template *ngIf="transaction.from === address.hash; then sentAction; else receivedAction"></ng-template>
-            <ng-template #sentAction>
-              <a [routerLink]="['/explorer', 'address', transaction.to]" class="transaction-action-link">
-                <div class="transaction-action">
-                  <span class="text-truncate"><span class="bold text-uppercase">TO</span> {{ transaction.to }}</span>
+              <a [routerLink]="['/explorer', 'transaction', transaction.hash]" class="transaction-hash-link">
+                <div class="transaction-hash">
+                  <span class="text-truncate">
+                    {{ transaction.hash }}
+                  </span>
                 </div>
               </a>
-            </ng-template>
-            <ng-template #receivedAction>
-              <a [routerLink]="['/explorer', 'address', transaction.from]" class="transaction-action-link">
-                <div class="transaction-action">
-                  <span class="text-truncate"><span class="bold text-uppercase">FROM</span> {{ transaction.from }}</span>
-                </div>
-              </a>
-            </ng-template>
-            <div class="transaction-value">
-              {{ transaction.value | number:'1.0-5' }} AKA
-            </div>
-            <div class="transaction-timestamp">
-              {{ transaction.timestamp | unixTimestampToDate | date:'yyyy-MM-dd HH:mm:ss' }}
+              <ng-template *ngIf="transaction.from === address.hash; then sentAction; else receivedAction"></ng-template>
+              <ng-template #sentAction>
+                <a [routerLink]="['/explorer', 'address', transaction.to]" class="transaction-action-link">
+                  <div class="transaction-action">
+                    <span class="text-truncate"><span class="bold text-uppercase">TO</span> {{ transaction.to }}</span>
+                  </div>
+                </a>
+              </ng-template>
+              <ng-template #receivedAction>
+                <a [routerLink]="['/explorer', 'address', transaction.from]" class="transaction-action-link">
+                  <div class="transaction-action">
+                    <span class="text-truncate"><span class="bold text-uppercase">FROM</span> {{ transaction.from }}</span>
+                  </div>
+                </a>
+              </ng-template>
+              <div class="transaction-value">
+                {{ transaction.value | number:'1.0-5' }} AKA
+              </div>
+              <div class="transaction-timestamp">
+                {{ transaction.timestamp | unixTimestampToDate | date:'yyyy-MM-dd HH:mm:ss' }}
+              </div>
             </div>
           </div>
         </div>
-      </div>
+      </ng-container>
     </div>
   </div>
 </ng-container>

--- a/src/app/explorer/pages/address-details/address-details.component.scss
+++ b/src/app/explorer/pages/address-details/address-details.component.scss
@@ -226,3 +226,19 @@ a:hover {
 .bold {
   font-weight: 700;
 }
+
+:host ::ng-deep ul.pagination li.page-item a.page-link {
+  background-color: #f4f4f4;
+  border-color: #f4f4f4;
+  border-radius: 0;
+  color: #333333;
+  font-weight: 600;
+  text-align: center;
+  width: 35px;
+}
+
+:host ::ng-deep ul.pagination li.active a.page-link {
+  background-color: #9B9B9B;
+  border-color: #9B9B9B;
+  color: #4A4A4A;
+}

--- a/src/app/explorer/pages/address-details/address-details.component.scss
+++ b/src/app/explorer/pages/address-details/address-details.component.scss
@@ -232,7 +232,7 @@ a:hover {
   border-color: #f4f4f4;
   border-radius: 0;
   color: #333333;
-  font-weight: 600;
+  font-weight: 700;
   text-align: center;
   width: 35px;
 }
@@ -241,4 +241,15 @@ a:hover {
   background-color: #9B9B9B;
   border-color: #9B9B9B;
   color: #4A4A4A;
+}
+
+:host ::ng-deep ul.pagination li.pagination-prev a.page-link,
+:host ::ng-deep ul.pagination li.pagination-next a.page-link {
+  background-image: url('../../../../assets/images/icon-arrow-left.svg');
+  background-position: center center;
+  background-repeat: no-repeat;
+}
+
+:host ::ng-deep ul.pagination li.pagination-next a.page-link {
+  transform: rotate(180deg);
 }

--- a/src/app/explorer/pages/address-details/address-details.component.spec.ts
+++ b/src/app/explorer/pages/address-details/address-details.component.spec.ts
@@ -1,10 +1,14 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed, async } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
 import { RouterTestingModule } from '@angular/router/testing';
 import { StoreModule, combineReducers } from '@ngrx/store';
+import { PaginationModule } from 'ngx-bootstrap';
 
 import * as fromRoot from '../../../core/state/reducers';
 import { HexToAsciiPipe } from '../../pipes/hex-to-ascii.pipe';
 import { UnixTimestampToDatePipe } from '../../pipes/unix-timestamp-to-date.pipe';
+import { AddressesService } from '../../services/addresses.service';
 import * as fromExplorer from '../../state/reducers';
 
 import { AddressDetailsComponent } from './address-details.component';
@@ -22,11 +26,17 @@ describe('AddressDetailsComponent', () => {
             ...fromRoot.reducers,
             explorer: combineReducers(fromExplorer.reducers),
           }),
+          PaginationModule.forRoot(),
+          FormsModule,
+          HttpClientTestingModule,
         ],
         declarations: [
           AddressDetailsComponent,
           HexToAsciiPipe,
           UnixTimestampToDatePipe,
+        ],
+        providers: [
+          AddressesService,
         ],
       })
       .compileComponents();

--- a/src/app/explorer/pages/address-details/address-details.component.ts
+++ b/src/app/explorer/pages/address-details/address-details.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { Store } from '@ngrx/store';
 import { Observable } from 'rxjs/Observable';
@@ -25,7 +25,6 @@ export class AddressDetailsComponent implements OnInit {
     private route: ActivatedRoute,
     private store: Store<State>,
     private addressesService: AddressesService,
-    private ref: ChangeDetectorRef,
   ) { }
 
   ngOnInit() {

--- a/src/app/explorer/pages/address-details/address-details.component.ts
+++ b/src/app/explorer/pages/address-details/address-details.component.ts
@@ -3,6 +3,8 @@ import { Store } from '@ngrx/store';
 import { Observable } from 'rxjs/Observable';
 
 import { Address } from '../../models/address';
+import { AddressTransactions } from '../../models/address-transactions';
+import { AddressesService } from '../../services/addresses.service';
 import { State } from '../../state/reducers';
 import { getSelectedAddress } from '../../state/selectors/addresses.selectors';
 
@@ -14,12 +16,23 @@ import { getSelectedAddress } from '../../state/selectors/addresses.selectors';
 })
 export class AddressDetailsComponent implements OnInit {
   address$: Observable<Address>;
+  addressTransactions$: Observable<AddressTransactions>;
 
   constructor(
     private store: Store<State>,
+    private addressesService: AddressesService,
   ) { }
 
   ngOnInit() {
     this.address$ = this.store.select(getSelectedAddress);
+    this.address$.subscribe(
+      (response: Address) => {
+        this.pageNextAddressTransactions(response.hash);
+      },
+    );
+  }
+
+  pageNextAddressTransactions(address: string, page: number = 0) {
+    this.addressTransactions$ = this.addressesService.getAddressTransactions(address, page);
   }
 }

--- a/src/app/explorer/pages/address-details/address-details.component.ts
+++ b/src/app/explorer/pages/address-details/address-details.component.ts
@@ -29,21 +29,18 @@ export class AddressDetailsComponent implements OnInit {
   ) { }
 
   ngOnInit() {
-    this.address$ = this.store.select(getSelectedAddress);
-    this.pageAddressTransactions({ page: 1 });
-    // this.address$.subscribe(
-    //   (response: Address) => {
-    //     this.pageAddressTransactions({ page: 1 });
-    //   },
-    // ).unsubscribe();
+    this.route.params.subscribe(params => {
+      this.address$ = this.store.select(getSelectedAddress);
+      this.pageAddressTransactions({ init: true, page: 1 });
+    });
   }
 
   pageAddressTransactions(event: any) {
-    this.addressesService.getAddressTransactions(this.route.snapshot.params.addressHash, event.page - 1)
-    .subscribe((result: AddressTransactions) => {
-      this.addressTransactions = { ...result };
-      this.currentPage = result.currentPage + 1;
-      this.ref.markForCheck();
-    });
+    // guard to prevent excess firing
+    if (this.currentPage === event.page && !event.init) {
+      return;
+    }
+    this.addressTransactions$ = this.addressesService.getAddressTransactions(this.route.snapshot.params.addressHash, event.page - 1);
+    this.currentPage = event.page;
   }
 }

--- a/src/app/explorer/services/addresses.service.ts
+++ b/src/app/explorer/services/addresses.service.ts
@@ -1,9 +1,11 @@
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 
 import { environment } from '../../../environments/environment';
 import { Address } from '../models/address';
+import { AddressTransactions } from '../models/address-transactions';
+import { Transaction } from '../models/transaction';
 
 @Injectable()
 export class AddressesService {
@@ -14,6 +16,12 @@ export class AddressesService {
   getAddress(addressHash: string): Observable<Address> {
     return this.http
       .get<Address>(`${environment.apiUrl}/addresses/${addressHash}`);
+  }
+
+  getAddressTransactions(address: string, page: number = 0): Observable<AddressTransactions> {
+    const params = { params: new HttpParams().set('page', page.toString()) };
+    return this.http
+      .get<AddressTransactions>(`${environment.apiUrl}/addresses/${address}/transactions`, params);
   }
 
 }

--- a/src/app/explorer/services/addresses.service.ts
+++ b/src/app/explorer/services/addresses.service.ts
@@ -5,7 +5,6 @@ import { Observable } from 'rxjs/Observable';
 import { environment } from '../../../environments/environment';
 import { Address } from '../models/address';
 import { AddressTransactions } from '../models/address-transactions';
-import { Transaction } from '../models/transaction';
 
 @Injectable()
 export class AddressesService {

--- a/src/assets/images/icon-arrow-left.svg
+++ b/src/assets/images/icon-arrow-left.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="16px" height="12px" viewBox="0 0 16 12" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 49 (51002) - http://www.bohemiancoding.com/sketch -->
+    <title>icon-arrow-left</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Explorer" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="akroma-explorer-d-blocks" transform="translate(-56.000000, -762.000000)" fill="#4A4A4A">
+            <g id="pagination" transform="translate(45.000000, 748.000000)">
+                <path d="M16.492,25.7790394 L11,20.0003946 L16.492,14.2217497 C16.772,13.9260834 17.227,13.9260834 17.508,14.2217497 C17.782,14.5100506 17.789,14.97512 17.522,15.2728907 L14,19.2112497 L26.25,19.2112497 C26.664,19.2112497 27,19.5647866 27,20.0003946 C27,20.4360025 26.664,20.7895394 26.25,20.7895394 L14.005,20.7895394 L17.523,24.7278985 C17.789,25.0246169 17.782,25.4907385 17.508,25.7790394 C17.227,26.0736535 16.772,26.0736535 16.492,25.7790394" id="icon-arrow-left"></path>
+            </g>
+        </g>
+    </g>
+</svg>


### PR DESCRIPTION
Closes #21 

Pagination for the address detail page transactions. Currently bypassing the use of transactions from our stock data object (`Address`), since it only contains 10. Choosing to start from page 0 (page 1). I had to monkey patch a little with styling the `pagination` component from `ngx-bootstrap`, any input would be great on this.

Works on all window sizes.
https://imgur.com/a/DWx47